### PR TITLE
BUG: Fix, simplify and modernize the build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,34 +1,37 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
-set(PROJECT_NAME Mesh)
-project(${PROJECT_NAME})
-set(CMAKE_BUILD_TYPE Release)
+project(MeshLib VERSION "1.0.0")
+
+# Set a default build type if none was specified
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to 'RelWithDebInfo' as none was specified.")
+  set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Choose the type of build." FORCE)
+  mark_as_advanced(CMAKE_BUILD_TYPE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY lib)
+set(MeshLib_INSTALL_CONFIG_DIR "lib/cmake/Mesh-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
 
-SET(VERSION_MAJOR "1")
-SET(VERSION_MINOR "0")
-SET(VERSION_PATCH "0")
-
-# recursive call: header directories
-MACRO(HEADER_DIRECTORIES return_list)
-	FILE(GLOB_RECURSE new_list include/*.h)
-	SET(dir_list "")
-	FOREACH(file_path ${new_list})
-		GET_FILENAME_COMPONENT(dir_path ${file_path} PATH)
-		SET(dir_list ${dir_list} ${dir_path})
-	ENDFOREACH()
-	LIST(REMOVE_DUPLICATES dir_list)
-	SET(${return_list} ${dir_list})
-ENDMACRO()
-HEADER_DIRECTORIES(HEADER_DIR)
-include_directories(${HEADER_DIR})
-
-set(SRC_FILES src/Mesh.cpp src/MeshIO.cpp src/MNIObjIO.cpp src/VtkIO.cpp)
-set(SRC_UTIL_FILES src/Util/Geom.cpp src/Util/AABB.cpp src/Util/Slicer.cpp src/Util/SphericalHarmonics.cpp src/Util/SurfaceUtil.cpp)
-
-# External libraries
-# geodesic distance
-set(SRC_GEOD_FILES src/Geodesic/Geodesic.cpp src/Geodesic/GeodesicA.cpp
+set(SRC_FILES
+  src/Mesh.cpp
+  src/MeshIO.cpp
+  src/MNIObjIO.cpp
+  src/VtkIO.cpp
+  )
+set(SRC_UTIL_FILES 
+  src/Util/Geom.cpp
+  src/Util/AABB.cpp
+  src/Util/Slicer.cpp
+  src/Util/SphericalHarmonics.cpp
+  src/Util/SurfaceUtil.cpp
+  )
+set(SRC_GEOD_FILES
+	src/Geodesic/Geodesic.cpp
+	src/Geodesic/GeodesicA.cpp
 	src/Geodesic/gw/gw_core/GW_Config.cpp
 	src/Geodesic/gw/gw_core/GW_FaceIterator.cpp
 	src/Geodesic/gw/gw_core/GW_SmartCounter.cpp
@@ -44,16 +47,21 @@ set(SRC_GEOD_FILES src/Geodesic/Geodesic.cpp src/Geodesic/GeodesicA.cpp
 	src/Geodesic/gw/gw_geodesic/GW_TriangularInterpolation_Cubic.cpp
 	src/Geodesic/gw/gw_geodesic/GW_GeodesicVertex.cpp
 	src/Geodesic/gw/gw_geodesic/GW_TriangularInterpolation_Linear.cpp
-	src/Geodesic/gw/gw_geodesic/GW_TriangularInterpolation_Quadratic.cpp)
+	src/Geodesic/gw/gw_geodesic/GW_TriangularInterpolation_Quadratic.cpp
+  )
 
-option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
-
-if(BUILD_SHARED_LIBS)
-	set(BUILD_SHARED SHARED)
-endif(BUILD_SHARED_LIBS)
-
-add_library(Mesh ${BUILD_SHARED} ${SRC_FILES} ${SRC_UTIL_FILES} ${SRC_GEOD_FILES})
+add_library(Mesh ${SRC_FILES} ${SRC_UTIL_FILES} ${SRC_GEOD_FILES})
 set_target_properties(Mesh PROPERTIES SOVERSION 1.0)
+target_include_directories(Mesh PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/Geodesic>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/Geodesic/gw>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/Geodesic/gw/gw_core>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/Geodesic/gw/gw_geodesic>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/Geodesic/gw/gw_maths>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/Util>
+  $<INSTALL_INTERFACE:include>
+  )
 
 if(APPLE)
     # use, i.e. don't skip the full RPATH for the build tree
@@ -69,7 +77,6 @@ if(APPLE)
     # which point to directories outside the build tree to the install RPATH
     SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-
     # the RPATH to be used when installing, but only if it's not a system directory
     LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
     IF("${isSystemDir}" STREQUAL "-1")
@@ -77,21 +84,51 @@ if(APPLE)
     ENDIF("${isSystemDir}" STREQUAL "-1")
 endif(APPLE)
 
-FILE(GLOB_RECURSE MESHLIB_HEADERS include/*.h)
+file(GLOB_RECURSE MESHLIB_HEADERS include/*.h)
+install(
+  FILES ${MESHLIB_HEADERS}
+  DESTINATION include COMPONENT Development
+  )
 
-install(FILES
-    ${MESHLIB_HEADERS}
-    DESTINATION include
-    COMPONENT dev)
+install(TARGETS Mesh EXPORT MeshLibTargets
+  LIBRARY DESTINATION lib COMPONENT RuntimeLibraries
+  ARCHIVE DESTINATION lib COMPONENT Development
+  )
 
-install(TARGETS Mesh
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib)
+# Configure 'MeshLibTargets.cmake'
+export(EXPORT MeshLibTargets FILE ${PROJECT_BINARY_DIR}/MeshLibTargets.cmake)
 
+# Configure 'MeshLibConfig.cmake' for a build tree
+include(CMakePackageConfigHelpers)
+set(build_config ${PROJECT_BINARY_DIR}/MeshLibConfig.cmake)
+configure_package_config_file(
+  MeshLibConfig.cmake.in
+  ${build_config}
+  INSTALL_DESTINATION ${PROJECT_BINARY_DIR}
+  INSTALL_PREFIX ${PROJECT_BINARY_DIR}
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+  )
 
-configure_file(MeshLibConfig.cmake.in
- "${PROJECT_BINARY_DIR}/MeshLibConfig.cmake" @ONLY)
-install(FILES
-    ${PROJECT_BINARY_DIR}/MeshLibConfig.cmake
-    DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/cmake/${PROJECT_NAME}-${VERSION_MAJOR}.${VERSION_MINOR}"
-    COMPONENT dev)
+# Configure 'MeshLibConfig.cmake' for an install tree
+set(install_config ${PROJECT_BINARY_DIR}/CMakeFiles/MeshLibConfig.cmake)
+configure_package_config_file(
+  MeshLibConfig.cmake.in
+  ${install_config}
+  INSTALL_DESTINATION ${MeshLib_INSTALL_CONFIG_DIR}
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+  )
+
+# Install 'MeshLibConfig.cmake'
+install(
+  FILES ${install_config}
+  DESTINATION ${MeshLib_INSTALL_CONFIG_DIR}
+  COMPONENT Development
+  )
+
+# Install 'MeshLibTargets.cmake'
+install(EXPORT MeshLibTargets
+  FILE MeshLibTargets.cmake
+  DESTINATION ${MeshLib_INSTALL_CONFIG_DIR}
+  COMPONENT Development
+  )
+

--- a/MeshLibConfig.cmake.in
+++ b/MeshLibConfig.cmake.in
@@ -1,19 +1,8 @@
-# - Config file for the FADTTS package
-# It defines the following variables
+@PACKAGE_INIT@
 
-# Compute paths
+set_and_check(MeshLib_TARGETS "${CMAKE_CURRENT_LIST_DIR}/MeshLibTargets.cmake")
 
-get_filename_component(Mesh_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-
-
-file(TO_CMAKE_PATH "${Mesh_CMAKE_DIR}/../../../include" Mesh_INCLUDE_DIRS)
-file(TO_CMAKE_PATH "${Mesh_CMAKE_DIR}/../../" Mesh_LIBRARY_DIRS)
-
-include_directories(${Mesh_INCLUDE_DIRS})
-link_directories(${Mesh_LIBRARY_DIRS})
-
-set(Mesh_LIBRARIES Mesh)
-
-message(STATUS "\t Mesh_INCLUDE_DIRS=" ${Mesh_INCLUDE_DIRS})
-message(STATUS "\t Mesh_LIBRARIES=" ${Mesh_LIBRARIES})
-message(STATUS "\t Mesh_LIBRARY_DIRS=" ${Mesh_LIBRARY_DIRS})
+if(NOT MeshLib_TARGETS_IMPORTED)
+  set(MeshLib_TARGETS_IMPORTED 1)
+  include(${MeshLib_TARGETS})
+endif()


### PR DESCRIPTION
This commit updates the build system so that the library can be used
from either a build or install tree.

* update minimum required CMake version from 2.8 to 3.5
* associated include directories with targets. See [1]
* fix handling of CMAKE_BUILD_TYPE and CMAKE_CONFIGURATION_TYPES

[1] https://cmake.org/cmake/help/v3.5/manual/cmake-buildsystem.7.html#include-directories-and-usage-requirements